### PR TITLE
Fix server flags collision

### DIFF
--- a/.kuber/client.yaml
+++ b/.kuber/client.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: client
-        image: ghcr.io/rosowskimik/shorty-client:v0.2.0
+        image: ghcr.io/rosowskimik/shorty-client:v0.2.1
         ports:
         - containerPort: 8080
           name: client-port

--- a/.kuber/server.yaml
+++ b/.kuber/server.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: ghcr.io/rosowskimik/shorty-server:v0.2.0
+        image: ghcr.io/rosowskimik/shorty-server:v0.2.1
         ports:
         - containerPort: 50001
           name: server-port

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum 0.7.5",
  "clap",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bb8",
  "bb8-redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["client", "server"]
 
 [workspace.package]
 authors = ["Mikołaj Rosowski <m.rosowski@wp.pl>"]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Leptos/GRPC Url Shortener
+# Leptos + gRPC Url Shortener
 
 Simple url shortener app written in Rust (Leptos app with hydration) + gRPC backend.
 Used for Kubernetes course.
@@ -12,6 +12,8 @@ Main access point for rest of the app.
 
 The gRPC `.proto` files are available in [proto directory](./proto).
 
+(more details about specific elements is contained within their respective directories)
+
 # Building
 
 ## Dependencies
@@ -19,7 +21,7 @@ To build both `client` and `server`, you will need:
 - Rust nightly
 - Protocol buffers compiler
 
-additionaly, to build the `client` app:
+additionally, to build the `client` app:
 - [`cargo-leptos`](https://github.com/leptos-rs/leptos)
 
 ## Client

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,37 @@
+# Client
+
+The UI component of the entire application.
+This is a SSR application written in Rust using [Leptos framework](https://leptos.dev) with [Axum](https://github.com/tokio-rs/axum) integration.
+
+## App startup
+
+The app goes through three main steps when started.
+
+1. The app parses basic configuration options and exists with an error if any of the required ones are missing.
+Args can be provided either as command flags or (more safely) as environment variables.
+If an option is passed as both, the flag value takes priority.
+
+All cli options, their environment counterparts and default values can be checked by passing
+`--help` to the client binary.
+
+2. After parsing the configuration, the client will attempt to establish a connection with gRPC server,
+which handles the shortening logic. The connection will be attempted up to 5 times after which,
+if connection isn't established, the client will exit early with an error.
+
+3. With connection established, the app will start up the Axum server responsible for
+serving the frontend WASM application and the public facing API.
+
+The frontend server is configured to use gzip compression to minimize served bundle size.
+
+# API
+
+Besides sevring static files (HTML, CSS, WASM), the frontend server exposes specialized routes
+for handling the application logic
+
+* `GET /s/<slug>` - the shortened URL route. When a matching `slug` is found, the server will respond with
+`303 See Other` response, redirecting the client to the original URL. If no match is found, responds with generic `404 Not Found`.
+
+* `GET, POST /api/*` - routes generated automatically by Leptos to handle its [server functions](https://book.leptos.dev/server/25_server_functions.html).
+
+If none of those routes match, the server will check if the request corresponds to a static file
+and serve it if match is found. Otherwise it responds with generic `404 Not Found`.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,80 @@
+# Server
+
+The backend component of the entire application
+This is an async Rust server application using [Tokio](https://tokio.rs/) and [Tonic](https://github.com/hyperium/tonic) to implement a [gRPC](https://grpc.io/) URL shortener service.
+
+## App startup
+
+The app goes through three main steps when started.
+
+1. The app parses basic configuration options and exists with an error if any of the required ones are missing.
+Args can be provided either as command flags or (more safely) as environment variables.
+If an option is passed as both, the flag value takes priority.
+
+All cli options, their environment counterparts and default values can be checked by passing
+`--help` to the server binary.
+
+2. After parsing the configuration, the server will attempt to establish a connection with a database
+used to store the URL mappings. If that fails, the server will exit early with an error.
+
+3. With connection established, the app will start up the gRPC server responsible for
+handling URL shortening requests.
+
+## Shortener
+
+### URL -> slug
+
+When the server receives an URL shortening request, it goes through these steps:
+
+1. The data contained within request body is checked first, to make sure that it is a valid URL.
+If the validation fails, the server responds with an error
+
+2. Next, a random, ASCII alphanumeric (a-z, A-Z and 0-9) string of preconfigured length is generated
+to be used as the short slug.
+
+3. After that, the server attempts to save the new mapping to the database
+
+4. If that succeeds, the server sends back the response containing the newly generated slug.
+
+### Slug -> URL
+
+When the server receives a URL mapping fetch request, it goes through these steps:
+
+1. The server checks if the requested URL mapping exists in the database,
+using the slug provided in request body as a loookup key.
+
+2. Depending on the lookup result, the server either responds with an OK message containing the original URL,
+or not found error.
+
+### Short slug generation
+
+The slugs are generated using [xoshiro256++](https://prng.di.unimi.it/xoshiro256plusplus.c)
+pseudo random number generator over uniformly distributed ASCII letters and numbers.
+
+Each application thread gets it's own instance by storing it in thread local storage.
+Each generator is lazily seeded on first usage with current system time in form of UNIX timestamp
+(number of seconds since 1970-01-01 00:00:00 UTC)
+
+## Database
+
+[Redis](https://redis.io/), or any Redis compatible (like [keydb](https://docs.keydb.dev/)) database can be used.
+The server will use this database to store the generated slug -> original URL mappings.
+
+### Master - replicas setup
+
+By default, if only one database connection is configured,
+that database will be used for all requests by the server.
+However, the server can also be configured to support master - replicas clusters.
+If a replica database connection is configured,
+all data modifying requests (writes) will be directed to the master database,
+while immutable requests (reads) will sent to the replicas by the server.
+This could possibly improve throughput, especially when reading data back,
+since all read requests can be load balanced across many replicas.
+
+This also doubles as an additional failover strategy:
+
+* when a read request to a replica fails, the server will attempt to read directly from master
+* in case of master failure, the replicas can still handle all read requests for existing data
+
+> [!NOTE]
+> The master - replicas cluster setup if the default when using provided `kubernetes` configuration

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -31,7 +31,7 @@ pub(crate) struct Cli {
     database: String,
 
     /// Database readonly replica connection string
-    #[arg(short, long, env = "SERVER_DATABASE_REPLICA")]
+    #[arg(short = 'r', long, env = "SERVER_DATABASE_REPLICA")]
     database_ro: Option<String>,
 
     /// Server token


### PR DESCRIPTION
Fixes collision of short flags on server app for `database` and `database-ro`.
Bumped version in `Cargo.toml` and kubernetes files.

Also adds detailed description to both server and client